### PR TITLE
Eval hash table

### DIFF
--- a/Loki/Loki.vcxproj
+++ b/Loki/Loki.vcxproj
@@ -151,6 +151,7 @@
   <ItemGroup>
     <ClCompile Include="bench.cpp" />
     <ClCompile Include="bitboard.cpp" />
+    <ClCompile Include="evaltable.cpp" />
     <ClCompile Include="evaluation.cpp" />
     <ClCompile Include="magics.cpp" />
     <ClCompile Include="main.cpp">
@@ -178,6 +179,7 @@
     <ClInclude Include="bench.h" />
     <ClInclude Include="bitboard.h" />
     <ClInclude Include="defs.h" />
+    <ClInclude Include="evaltable.h" />
     <ClInclude Include="evaluation.h" />
     <ClInclude Include="misc.h" />
     <ClInclude Include="move.h" />

--- a/Loki/Loki.vcxproj.filters
+++ b/Loki/Loki.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="tt_entry.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="evaltable.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="bitboard.h">
@@ -126,6 +129,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="tt_entry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="evaltable.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Loki/defs.h
+++ b/Loki/defs.h
@@ -82,9 +82,6 @@ constexpr int VALUE_NONE = 50000;
 #define THREADS_DEFAULT_NUM 1
 #define THREADS_MIN_NUM 1
 
-// Default eval table size.
-#define DEFAULT_EVAL_TABLE_SIZE 200
-
 typedef uint64_t Bitboard;
 
 

--- a/Loki/evaltable.cpp
+++ b/Loki/evaltable.cpp
@@ -16,3 +16,53 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "evaltable.h"
+
+
+
+/// <summary>
+/// Default constructor for the evaluation table. It allocates memory for the entries.
+/// </summary>
+EvaluationTable::EvaluationTable() {
+	num_slots = EVAL_TABLE_SIZE / sizeof(EvalEntry_t);
+	entries = new EvalEntry_t[num_slots];
+}
+
+/// <summary>
+/// Destructor. Frees the memory allocated during construction.
+/// </summary>
+EvaluationTable::~EvaluationTable() {
+	if (entries != nullptr) { delete[] entries; }
+}
+
+
+/// <summary>
+/// Store an entry in the table.
+/// </summary>
+/// <param name="key">The position's zobrist hash key.</param>
+/// <param name="eval">The static evaluation of the position.</param>
+void EvaluationTable::store(uint64_t key, int eval) {
+	EvalEntry_t* entry = &entries[key & (num_slots - 1)];
+
+	entry->set(key, eval);
+}
+
+
+/// <summary>
+/// Probe the table to see if a pre-calculated evaluation exists for the position.
+/// </summary>
+/// <param name="key">The position's zobrist hash key.</param>
+/// <param name="hit">A reference to a flag signalling if the got a hit.</param>
+/// <returns>In case of a hit: A pointer to the entry. Otherwise, a null pointer.</returns>
+const EvalEntry_t* EvaluationTable::probe(uint64_t key, bool& hit) {
+	const EvalEntry_t* entry = &entries[key & (num_slots - 1)];
+
+	// Step 1. If the keys match, we have a hit.
+	if (entry->get_key() == (key >> 32)) {
+		hit = true;
+		return entry;
+	}
+
+	// Step 2. Otherwise, return a null pointer.
+	hit = false;
+	return nullptr;
+}

--- a/Loki/evaltable.cpp
+++ b/Loki/evaltable.cpp
@@ -1,0 +1,18 @@
+/*
+	Loki, a UCI-compliant chess playing software
+	Copyright (C) 2021  Niels Abildskov (https://github.com/BimmerBass)
+
+	Loki is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Loki is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include "evaltable.h"

--- a/Loki/evaltable.h
+++ b/Loki/evaltable.h
@@ -1,0 +1,25 @@
+/*
+	Loki, a UCI-compliant chess playing software
+	Copyright (C) 2021  Niels Abildskov (https://github.com/BimmerBass)
+
+	Loki is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Loki is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef EVALTABLE_H
+#define EVALTABLE_H
+
+
+
+
+
+#endif

--- a/Loki/evaltable.h
+++ b/Loki/evaltable.h
@@ -19,16 +19,22 @@
 #define EVALTABLE_H
 #include <cstdint>
 
+/// <summary>
+/// The default size of the evaluation hash table in bytes. It is 128KB.
+/// </summary>
+constexpr size_t EVAL_TABLE_SIZE = 128 << 10;
+
+
 
 /// <summary>
 /// EvalEntry_t is the container for the data in a single entry in the evaluation hash table.
 /// </summary>
 class EvalEntry_t {
 public:
-	void set(uint64_t pos_key, int eval);
+	void set(uint64_t pos_key, int eval) { key = pos_key >> 32; score = eval; }
 
-	uint32_t get_key() const;
-	int get_score() const;
+	uint32_t get_key() const { return key; }
+	int get_score() const { return score; }
 private:
 	uint32_t key = 0;
 	int score = 0;

--- a/Loki/evaltable.h
+++ b/Loki/evaltable.h
@@ -17,7 +17,41 @@
 */
 #ifndef EVALTABLE_H
 #define EVALTABLE_H
+#include <cstdint>
 
+
+/// <summary>
+/// EvalEntry_t is the container for the data in a single entry in the evaluation hash table.
+/// </summary>
+class EvalEntry_t {
+public:
+	void set(uint64_t pos_key, int eval);
+
+	uint32_t get_key() const;
+	int get_score() const;
+private:
+	uint32_t key = 0;
+	int score = 0;
+
+};
+
+
+
+/// <summary>
+/// EvaluationTable is the class responsible for managing the evaluation hash table.
+/// </summary>
+class EvaluationTable {
+public:
+	EvaluationTable();
+	~EvaluationTable();
+
+	void store(uint64_t key, int eval);
+	const EvalEntry_t* probe(uint64_t key, bool& hit);
+
+private:
+	size_t num_slots = 0;
+	EvalEntry_t* entries;
+};
 
 
 

--- a/Loki/evaluation.h
+++ b/Loki/evaluation.h
@@ -21,6 +21,7 @@
 #include <array>
 #include "movegen.h"
 #include "test_positions.h"
+#include "evaltable.h"
 
 
 /*
@@ -91,6 +92,9 @@ namespace Eval {
 		template<SIDE S> void space();
 		template<SIDE S, piece pce> void mobility();
 		template<SIDE S> void king_safety();
+
+		// An evaluation hash table to re-use recently calculated evaluations.
+		EvaluationTable eval_table;
 	};
 	
 	


### PR DESCRIPTION
SPRT test results against master:
Score of Lokidev vs master: 374 - 298 - 482  [0.533] 1154
...      Lokidev playing White: 219 - 120 - 239  [0.586] 578
...      Lokidev playing Black: 155 - 178 - 243  [0.480] 576
...      White vs Black: 397 - 275 - 482  [0.553] 1154
Elo difference: 22.9 +/- 15.3, LOS: 99.8 %, DrawRatio: 41.8 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted

An evaluation hash table therefore gives ~23 elo.